### PR TITLE
fix(Loop): backtesting should only update online (not mini-batch) models, necessary for generating out-of-sample results

### DIFF
--- a/src/fold/loop/backtest.py
+++ b/src/fold/loop/backtest.py
@@ -80,11 +80,8 @@ def __backtest_on_window(
         transformation_over_time.loc[split.model_index]
         for transformation_over_time in transformations_over_time
     ]
-    current_transformations = (
-        current_transformations
-        if mutate
-        else deepcopy_transformations(current_transformations)
-    )
+    if not mutate:
+        current_transformations = deepcopy_transformations(current_transformations)
 
     X_test = X.iloc[split.test_window_start : split.test_window_end]
     y_test = y.iloc[split.test_window_start : split.test_window_end]
@@ -98,7 +95,7 @@ def __backtest_on_window(
         y_test,
         sample_weights_test,
         current_transformations,
-        stage=Stage.update,
+        stage=Stage.update_online_only,
     )
 
     return trim_initial_nans_single(X_test)

--- a/src/fold/loop/common.py
+++ b/src/fold/loop/common.py
@@ -16,6 +16,7 @@ from ..utils.checks import is_prediction
 class Stage(Enum):
     inital_fit = "inital_fit"
     update = "update"
+    update_online_only = "update_online_only"
     infer = "infer"
 
     def is_fit_or_update(self) -> bool:
@@ -111,7 +112,7 @@ def recursively_transform(
         # If the transformation needs to be "online", and we're in the update stage, we need to run the inner loop.
         if (
             transformations.properties.mode == Transformation.Properties.Mode.online
-            and stage == Stage.update
+            and stage in [Stage.update, Stage.update_online_only]
         ):
             y_df = y.to_frame() if y is not None else None
             # We need to run the inference & fit loop on each row, sequentially (one-by-one).
@@ -123,7 +124,7 @@ def recursively_transform(
                     transformations.update(X_row, y_row, sample_weights_row)
                 return result
 
-            concatenated = pd.concat(
+            return pd.concat(
                 [
                     transform_row_inference_backtest(
                         X.loc[index:index],
@@ -135,11 +136,6 @@ def recursively_transform(
                     for index in X.index
                 ],
                 axis="index",
-            )
-            return (
-                concatenated
-                if type(concatenated) is pd.DataFrame
-                else concatenated.to_frame()
             )
 
         # or the model is "mini-batch" updating or we're in initial_fit stage

--- a/tests/test_loop_train_methods.py
+++ b/tests/test_loop_train_methods.py
@@ -84,17 +84,17 @@ def test_loop_parallel_minibatch_call_times() -> None:
 
     _ = _backtest_and_mutate(transformations_over_time, X, y, splitter)
     assert transformations_over_time[0].iloc[0].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[0].no_of_calls_update == 1
+    assert transformations_over_time[0].iloc[0].no_of_calls_update == 0
     assert transformations_over_time[0].iloc[0].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[0].no_of_calls_transform_outofsample == 1
 
     assert transformations_over_time[0].iloc[1].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[1].no_of_calls_update == 1
+    assert transformations_over_time[0].iloc[1].no_of_calls_update == 0
     assert transformations_over_time[0].iloc[1].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[1].no_of_calls_transform_outofsample == 1
 
     assert transformations_over_time[0].iloc[2].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[2].no_of_calls_update == 1
+    assert transformations_over_time[0].iloc[2].no_of_calls_update == 0
     assert transformations_over_time[0].iloc[2].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[2].no_of_calls_transform_outofsample == 1
 
@@ -172,17 +172,17 @@ def test_loop_sequential_minibatch_call_times() -> None:
 
     _ = _backtest_and_mutate(transformations_over_time, X, y, splitter)
     assert transformations_over_time[0].iloc[0].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[0].no_of_calls_update == 1
+    assert transformations_over_time[0].iloc[0].no_of_calls_update == 0
     assert transformations_over_time[0].iloc[0].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[0].no_of_calls_transform_outofsample == 1
 
     assert transformations_over_time[0].iloc[1].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[1].no_of_calls_update == 2
+    assert transformations_over_time[0].iloc[1].no_of_calls_update == 1
     assert transformations_over_time[0].iloc[1].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[1].no_of_calls_transform_outofsample == 2
 
     assert transformations_over_time[0].iloc[2].no_of_calls_fit == 1
-    assert transformations_over_time[0].iloc[2].no_of_calls_update == 3
+    assert transformations_over_time[0].iloc[2].no_of_calls_update == 2
     assert transformations_over_time[0].iloc[2].no_of_calls_transform_insample == 1
     assert transformations_over_time[0].iloc[2].no_of_calls_transform_outofsample == 3
 


### PR DESCRIPTION
Closes #125 