### PR TITLE
feature(Loop): handled X being `None` and added test covering this case.

### DIFF
--- a/src/fold/loop/backtest.py
+++ b/src/fold/loop/backtest.py
@@ -12,7 +12,7 @@ from .types import Backend, Stage
 
 def backtest(
     transformations_over_time: TransformationsOverTime,
-    X: pd.DataFrame,
+    X: Optional[pd.DataFrame],
     y: pd.Series,
     splitter: Splitter,
     backend: Backend = Backend.no,
@@ -23,8 +23,10 @@ def backtest(
     Run backtest on a set of TransformationsOverTime and given data.
     Does not mutate or change the transformations in any way, aka you can backtest multiple times.
     """
-
-    assert type(X) is pd.DataFrame, "X must be a pandas DataFrame."
+    if X is None:
+        X = pd.DataFrame(0, index=y.index, columns=[0])
+    else:
+        assert type(X) is pd.DataFrame, "X must be a pandas DataFrame."
     assert type(y) is pd.Series, "y must be a pandas Series."
 
     results = [

--- a/src/fold/loop/train.py
+++ b/src/fold/loop/train.py
@@ -25,14 +25,17 @@ from .types import Backend, Stage, TrainMethod
 
 def train(
     transformations: BlocksOrWrappable,
-    X: pd.DataFrame,
+    X: Optional[pd.DataFrame],
     y: pd.Series,
     splitter: Splitter,
     sample_weights: Optional[pd.Series] = None,
     train_method: TrainMethod = TrainMethod.parallel,
     backend: Backend = Backend.no,
 ) -> TransformationsOverTime:
-    assert type(X) is pd.DataFrame, "X must be a pandas DataFrame."
+    if X is None:
+        X = pd.DataFrame(0, index=y.index, columns=[0])
+    else:
+        assert type(X) is pd.DataFrame, "X must be a pandas DataFrame."
     assert type(y) is pd.Series, "y must be a pandas Series."
     if type(splitter) is SlidingWindowSplitter:
         assert (

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -24,3 +24,23 @@ def test_baseline_naive_seasonal() -> None:
     assert (
         len(pred) == 600
     )  # should return non-NaN predictions for the all out-of-sample sets
+
+
+def test_univariate() -> None:
+    _, y = generate_sine_wave_data(1000)
+
+    def check_if_not_nan(x):
+        assert not x.isna().squeeze().any()
+
+    splitter = ExpandingWindowSplitter(initial_train_window=400, step=400)
+    transformations = [
+        BaselineNaiveSeasonal(seasonal_length=10),
+        Test(fit_func=check_if_not_nan, transform_func=lambda y: y),
+        OnlyPredictions(),
+    ]
+    transformations_over_time = train(transformations, None, y, splitter)
+    pred = backtest(transformations_over_time, None, y, splitter)
+    assert (pred.squeeze() == y.shift(10)[pred.index]).all()
+    assert (
+        len(pred) == 600
+    )  # should return non-NaN predictions for the all out-of-sample sets


### PR DESCRIPTION
Closes #71 