### PR TITLE
fix(Dataset): Data preprocessing now cuts `+1`.

### DIFF
--- a/src/fold/loop/encase.py
+++ b/src/fold/loop/encase.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def backtest_score(
     trained_pipelines: TrainedPipelines,
-    X: pd.DataFrame,
+    X: Optional[pd.DataFrame],
     y: pd.Series,
     splitter: Splitter,
     backend: Backend = Backend.no,
@@ -54,7 +54,7 @@ def backtest_score(
 
 def train_backtest_score(
     transformations: BlocksOrWrappable,
-    X: pd.DataFrame,
+    X: Optional[pd.DataFrame],
     y: pd.Series,
     splitter: Splitter = ExpandingWindowSplitter(initial_train_window=0.2, step=0.2),
     backend: Backend = Backend.no,

--- a/src/fold/utils/dataset.py
+++ b/src/fold/utils/dataset.py
@@ -44,7 +44,7 @@ def __process_dataset(
     if resample is not None:
         df = df.resample(resample).last()
     if shorten is not None:
-        df = df[:shorten]
+        df = df[: shorten + 1]
     y = df[target_col].shift(-1)[:-1]
     X = df[:-1]
 


### PR DESCRIPTION
because we cut the fist `NaN` value generated by shifting the dataset by one. `shorten` is expected to give back the same sized dataset.

Closes #