### PR TITLE
fix(Composited): don't expose internal flags in public `init()`, indent Examples in docstrings, remove "Returns" sections

### DIFF
--- a/src/fold/composites/columns.py
+++ b/src/fold/composites/columns.py
@@ -21,12 +21,6 @@ class PerColumnEnsemble(Composite):
     pipeline: Pipeline
         Pipeline (list of Pipeline) to ensemble
 
-    Returns
-    ----------
-    X: pd.DataFrame
-        Ensemble of outputs of passed in pipelines.
-    y: pd.Series
-        Target passed along.
     """
 
     properties = Composite.Properties()
@@ -81,12 +75,6 @@ class SkipNA(Composite):
     pipeline: Pipeline
         Pipeline (list of Pipeline) to ensemble
 
-    Returns
-    -------
-    X: pd.DataFrame
-        Original X that it has received.
-    y: pd.Series
-        Target passed along.
     """
 
     properties = Composite.Properties()
@@ -126,12 +114,6 @@ class PerColumnTransform(Composite):
     pipeline: Pipeline
         Pipeline that gets applied to each column
 
-    Returns
-    -------
-    X: pd.DataFrame
-        X with the pipeline applied to each column seperately.
-    y: pd.Series
-        Target passed along.
     """
 
     properties = Composite.Properties()

--- a/src/fold/composites/columns.py
+++ b/src/fold/composites/columns.py
@@ -20,8 +20,6 @@ class PerColumnEnsemble(Composite):
     ----------
     pipeline: Pipeline
         Pipeline (list of Pipeline) to ensemble
-    models_already_cloned: bool
-        For internal use. It determines if the pipeline has been copied or not.
 
     Returns
     ----------
@@ -34,10 +32,17 @@ class PerColumnEnsemble(Composite):
     properties = Composite.Properties()
     models_already_cloned = False
 
-    def __init__(self, pipeline: Pipeline, models_already_cloned: bool = False) -> None:
+    def __init__(self, pipeline: Pipeline) -> None:
         self.models: Pipelines = wrap_in_double_list_if_needed(pipeline)
         self.name = "PerColumnEnsemble-" + get_concatenated_names(self.models)
-        self.models_already_cloned = models_already_cloned
+
+    @classmethod
+    def from_cloned_instance(
+        cls, pipeline: Pipeline, models_already_cloned: bool
+    ) -> PerColumnEnsemble:
+        instance = cls(pipeline=pipeline)
+        instance.models_already_cloned = models_already_cloned
+        return instance
 
     def before_fit(self, X: pd.DataFrame) -> None:
         if not self.models_already_cloned:
@@ -59,7 +64,7 @@ class PerColumnEnsemble(Composite):
         return self.models
 
     def clone(self, clone_child_transformations: Callable) -> PerColumnEnsemble:
-        return PerColumnEnsemble(
+        return PerColumnEnsemble.from_cloned_instance(
             pipeline=clone_child_transformations(self.models),
             models_already_cloned=self.models_already_cloned,
         )
@@ -130,11 +135,19 @@ class PerColumnTransform(Composite):
     """
 
     properties = Composite.Properties()
+    pipeline_already_cloned = False
 
-    def __init__(self, pipeline: Pipeline, pipeline_already_cloned=False) -> None:
+    def __init__(self, pipeline: Pipeline) -> None:
         self.pipeline = wrap_in_double_list_if_needed(pipeline)
         self.name = "PerColumnTransform-" + get_concatenated_names(self.pipeline)
-        self.pipeline_already_cloned = pipeline_already_cloned
+
+    @classmethod
+    def from_cloned_instance(
+        cls, pipeline: Pipeline, pipeline_already_cloned: bool
+    ) -> PerColumnTransform:
+        instance = cls(pipeline=pipeline)
+        instance.pipeline_already_cloned = pipeline_already_cloned
+        return instance
 
     def before_fit(self, X: pd.DataFrame) -> None:
         if not self.pipeline_already_cloned:
@@ -155,7 +168,7 @@ class PerColumnTransform(Composite):
         return self.pipeline
 
     def clone(self, clone_child_transformations: Callable) -> PerColumnTransform:
-        return PerColumnTransform(
+        return PerColumnTransform.from_cloned_instance(
             pipeline=clone_child_transformations(self.pipeline),
             pipeline_already_cloned=self.pipeline_already_cloned,
         )

--- a/src/fold/composites/columns.py
+++ b/src/fold/composites/columns.py
@@ -19,7 +19,7 @@ class PerColumnEnsemble(Composite):
     Parameters
     ----------
     pipeline: Pipeline
-        Pipeline (list of Pipeline) to ensemble
+        Pipeline that get applied to every column, independently, their results then averaged.
 
     """
 
@@ -73,7 +73,7 @@ class SkipNA(Composite):
     Parameters
     ----------
     pipeline: Pipeline
-        Pipeline (list of Pipeline) to ensemble
+        Pipeline to run without NA values.
 
     """
 

--- a/src/fold/transformations/columns.py
+++ b/src/fold/transformations/columns.py
@@ -86,30 +86,24 @@ class OnlyProbabilities(Transformation):
     """
     Drops all columns except the output model(s)' probabilities.
 
-    Returns
-    -------
-    pd.DataFrame
-        DataFrame with only columns which names are starting with "probabilities_".
-
-
     Examples
     --------
-    >>> from fold.loop import train_backtest
-    >>> from fold.splitters import SlidingWindowSplitter
-    >>> from fold.transformations.columns import OnlyProbabilities
-    >>> from fold.models.dummy import DummyClassifier
-    >>> from fold.utils.tests import generate_sine_wave_data
-    >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
-    >>> pipeline = [DummyClassifier(1, [0, 1], [0.5, 0.5]), OnlyProbabilities()]
-    >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
-    >>> preds.head()
-                         probabilities_DummyClassifier_0  probabilities_DummyClassifier_1
-    2021-12-31 15:40:00                              0.5                              0.5
-    2021-12-31 15:41:00                              0.5                              0.5
-    2021-12-31 15:42:00                              0.5                              0.5
-    2021-12-31 15:43:00                              0.5                              0.5
-    2021-12-31 15:44:00                              0.5                              0.5
+        >>> from fold.loop import train_backtest
+        >>> from fold.splitters import SlidingWindowSplitter
+        >>> from fold.transformations.columns import OnlyProbabilities
+        >>> from fold.models.dummy import DummyClassifier
+        >>> from fold.utils.tests import generate_sine_wave_data
+        >>> X, y  = generate_sine_wave_data()
+        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> pipeline = [DummyClassifier(1, [0, 1], [0.5, 0.5]), OnlyProbabilities()]
+        >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
+        >>> preds.head()
+                             probabilities_DummyClassifier_0  probabilities_DummyClassifier_1
+        2021-12-31 15:40:00                              0.5                              0.5
+        2021-12-31 15:41:00                              0.5                              0.5
+        2021-12-31 15:42:00                              0.5                              0.5
+        2021-12-31 15:43:00                              0.5                              0.5
+        2021-12-31 15:44:00                              0.5                              0.5
 
     """
 


### PR DESCRIPTION
Closes #226