### PR TITLE
chore(Loop): Renamed `encase` convenience functions to match the client facing name.

### DIFF
--- a/src/fold/__init__.py
+++ b/src/fold/__init__.py
@@ -1,7 +1,5 @@
 from .loop.backtesting import backtest
-from .loop.encase import backtest_score as evaluate
-from .loop.encase import train_backtest
-from .loop.encase import train_backtest_score as train_evaluate
+from .loop.encase import evaluate, train_backtest, train_evaluate
 from .loop.training import train
 from .loop.types import Backend, TrainMethod
 from .splitters import (

--- a/src/fold/loop/__init__.py
+++ b/src/fold/loop/__init__.py
@@ -1,8 +1,4 @@
 from .backtesting import backtest
-from .encase import backtest_score
-from .encase import backtest_score as evaluate
-from .encase import train_backtest
-from .encase import train_backtest_score
-from .encase import train_backtest_score as train_evaluate
+from .encase import evaluate, train_backtest, train_evaluate
 from .training import train
 from .types import Backend, TrainMethod

--- a/src/fold/loop/encase.py
+++ b/src/fold/loop/encase.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from krisi import ScoreCard
 
 
-def backtest_score(
+def evaluate(
     trained_pipelines: TrainedPipelines,
     X: Optional[pd.DataFrame],
     y: pd.Series,
@@ -113,7 +113,7 @@ def train_backtest(
     return pred, trained_pipelines
 
 
-def train_backtest_score(
+def train_evaluate(
     transformations: BlocksOrWrappable,
     X: Optional[pd.DataFrame],
     y: pd.Series,
@@ -168,7 +168,7 @@ def train_backtest_score(
         transformations, X, y, splitter, sample_weights, train_method, backend, silent
     )
 
-    scorecard, pred = backtest_score(
+    scorecard, pred = evaluate(
         trained_pipelines,
         X,
         y,

--- a/src/fold/loop/encase.py
+++ b/src/fold/loop/encase.py
@@ -161,7 +161,7 @@ def train_backtest_score(
         A ScoreCard if `krisi` is available, else the result of the `evaluation_func` in a dict
     pred: OutOfSamplePredictions
         Predictions made with the pipeline
-    TrainedPipelines
+    trained_pipelines: TrainedPipelines
         The fitted pipeline
     """
     trained_pipelines = train(


### PR DESCRIPTION
Closes #