### PR TITLE
chore(Splitter): renamed SlidingWindowSplitter's `initial_train_window` to `train_window`

### DIFF
--- a/src/fold/composites/columns.py
+++ b/src/fold/composites/columns.py
@@ -31,7 +31,7 @@ class EnsembleEachColumn(Composite):
         >>> from sklearn.ensemble import RandomForestRegressor
         >>> from fold.utils.tests import generate_sine_wave_data
         >>> X, y  = generate_sine_wave_data()
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = EnsembleEachColumn(RandomForestRegressor())
         >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
 
@@ -105,7 +105,7 @@ class TransformEachColumn(Composite):
         2021-12-31 07:22:00  0.0251       1.0251
         2021-12-31 07:23:00  0.0377       1.0377
         2021-12-31 07:24:00  0.0502       1.0502
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = TransformEachColumn(lambda x: x + 1.0)
         >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
         >>> preds.head()
@@ -184,7 +184,7 @@ class SkipNA(Composite):
         >>> from fold.utils.tests import generate_zeros_and_ones
         >>> X, y  = generate_zeros_and_ones()
         >>> X[1:100] = np.nan
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = SkipNA(
         ...     pipeline=RandomForestClassifier(),
         ... )

--- a/src/fold/composites/concat.py
+++ b/src/fold/composites/concat.py
@@ -67,7 +67,7 @@ class Concat(Composite):
         >>> from fold.composites import Concat
         >>> from fold.utils.tests import generate_sine_wave_data
         >>> X, y  = generate_sine_wave_data()
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = Concat([
         ...     lambda X: X.assign(sine_plus_1=X["sine"] + 1),
         ...     lambda X: X.assign(sine_plus_2=X["sine"] + 2),

--- a/src/fold/composites/ensemble.py
+++ b/src/fold/composites/ensemble.py
@@ -30,7 +30,7 @@ class Ensemble(Composite):
         >>> from fold.models import DummyRegressor
         >>> from fold.utils.tests import generate_sine_wave_data
         >>> X, y  = generate_sine_wave_data()
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = Ensemble([
         ...     DummyRegressor(0.1),
         ...     DummyRegressor(0.9),

--- a/src/fold/composites/residual.py
+++ b/src/fold/composites/residual.py
@@ -49,7 +49,7 @@ class ModelResiduals(Composite):
         >>> from sklearn.linear_model import LinearRegression
         >>> from fold.utils.tests import generate_sine_wave_data
         >>> X, y  = generate_sine_wave_data()
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = ModelResiduals(
         ...     primary=LinearRegression(),
         ...     meta=RandomForestRegressor(),

--- a/src/fold/composites/sample.py
+++ b/src/fold/composites/sample.py
@@ -38,7 +38,7 @@ class Sample(Composite):
         >>> from imblearn.under_sampling import RandomUnderSampler
         >>> from fold.utils.tests import generate_zeros_and_ones_skewed
         >>> X, y  = generate_zeros_and_ones_skewed()
-        >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+        >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
         >>> pipeline = Sample(
         ...     sampler=RandomUnderSampler(),
         ...     pipeline=RandomForestClassifier(),

--- a/src/fold/composites/target.py
+++ b/src/fold/composites/target.py
@@ -44,7 +44,7 @@ class TransformTarget(Composite):
     >>> from fold.transformations import Difference
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = TransformTarget(
     ...     wrapped_pipeline=LinearRegression(),
     ...     y_pipeline=Difference(),

--- a/src/fold/models/baseline.py
+++ b/src/fold/models/baseline.py
@@ -23,7 +23,7 @@ class Naive(TimeSeriesModel):
     >>> from fold.models import Naive
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = Naive()
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> pd.concat([preds, y[preds.index]], axis=1).head()

--- a/src/fold/models/dummy.py
+++ b/src/fold/models/dummy.py
@@ -30,7 +30,7 @@ class DummyClassifier(Model):
     >>> from fold.models import DummyClassifier
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = DummyClassifier(1, [0, 1], [0.5, 0.5])
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()
@@ -100,7 +100,7 @@ class DummyRegressor(Model, Tunable):
     >>> from fold.models import DummyRegressor
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = DummyRegressor(0.1)
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()

--- a/src/fold/models/random.py
+++ b/src/fold/models/random.py
@@ -32,7 +32,7 @@ class RandomClassifier(Model):
     >>> from fold.models import RandomClassifier
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> np.random.seed(42)
     >>> pipeline = RandomClassifier([0,1], 0.5)
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)

--- a/src/fold/splitters.py
+++ b/src/fold/splitters.py
@@ -43,8 +43,8 @@ class SlidingWindowSplitter(Splitter):
     Parameters
     ----------
 
-    initial_train_window : int, float
-        The initial training window size. If a float, it is interpreted as a fraction of the total length of the data.
+    train_window : int, float
+        The training window size. If a float, it is interpreted as a fraction of the total length of the data.
     step : int, float
         The step size of the sliding window. If a float, it is interpreted as a fraction of the total length of the data.
     embargo : int, optional
@@ -57,7 +57,7 @@ class SlidingWindowSplitter(Splitter):
 
     def __init__(
         self,
-        initial_train_window: Union[
+        train_window: Union[
             int, float
         ],  # this is what you don't out of sample get predictions for
         step: Union[int, float],
@@ -65,7 +65,7 @@ class SlidingWindowSplitter(Splitter):
         start: int = 0,
         end: Optional[int] = None,
     ) -> None:
-        self.window_size = initial_train_window
+        self.window_size = train_window
         self.step = step
         self.embargo = embargo
         self.start = start

--- a/src/fold/transformations/columns.py
+++ b/src/fold/transformations/columns.py
@@ -98,7 +98,7 @@ class RenameColumns(Transformation):
     >>> from fold.transformations import RenameColumns
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = RenameColumns({"sine": "sine_renamed"})
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()
@@ -140,7 +140,7 @@ class OnlyPredictions(Transformation):
     >>> from fold.models.dummy import DummyClassifier
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = [DummyClassifier(1, [0, 1], [0.5, 0.5]), OnlyPredictions()]
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()
@@ -186,7 +186,7 @@ class OnlyProbabilities(Transformation):
     >>> from fold.models.dummy import DummyClassifier
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = [DummyClassifier(1, [0, 1], [0.5, 0.5]), OnlyProbabilities()]
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()

--- a/src/fold/transformations/date.py
+++ b/src/fold/transformations/date.py
@@ -62,7 +62,7 @@ class AddDateTimeFeatures(Transformation, Tunable):
     >>> from fold.transformations import AddDateTimeFeatures
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddDateTimeFeatures(["minute"])
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()
@@ -140,7 +140,7 @@ class AddSecond(SingleFunctionTransformation):
     >>> from fold.transformations import AddSecond
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="S")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddSecond()
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()
@@ -172,7 +172,7 @@ class AddMinute(SingleFunctionTransformation):
     >>> from fold.transformations import AddMinute
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddMinute()
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()

--- a/src/fold/transformations/difference.py
+++ b/src/fold/transformations/difference.py
@@ -28,7 +28,7 @@ class Difference(InvertibleTransformation, Tunable):
     >>> from fold.transformations import Difference
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = Difference()
     >>> X["sine"].head()
     2021-12-31 07:20:00    0.0000
@@ -122,7 +122,7 @@ class TakeReturns(Transformation):
     >>> from fold.transformations import TakeReturns
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = TakeReturns()
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> X["sine"].loc[preds.index].head()

--- a/src/fold/transformations/lags.py
+++ b/src/fold/transformations/lags.py
@@ -28,7 +28,7 @@ class AddLagsY(Transformation, Tunable):
     >>> from fold.transformations import AddLagsY
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> _, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddLagsY([1,2,3])
     >>> preds, trained_pipeline = train_backtest(pipeline, None, y, splitter)
     >>> preds.head()
@@ -99,7 +99,7 @@ class AddLagsX(Transformation, Tunable):
     >>> from fold.transformations import AddLagsX
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddLagsX([("sine", 1), ("sine", [2,3])])
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()

--- a/src/fold/transformations/math.py
+++ b/src/fold/transformations/math.py
@@ -27,7 +27,7 @@ class TakeLog(InvertibleTransformation, Tunable):
     >>> from fold.transformations import TakeLog
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = TakeLog()
     >>> X["sine"].head()
     2021-12-31 07:20:00    0.0000
@@ -117,7 +117,7 @@ class AddConstant(InvertibleTransformation, Tunable):
     >>> from fold.transformations import AddConstant
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddConstant(1.0)
     >>> X["sine"].head()
     2021-12-31 07:20:00    0.0000
@@ -202,7 +202,7 @@ class TurnPositive(InvertibleTransformation):
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data(freq="min")
     >>> X, y  = X - 1, y - 1
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = TurnPositive()
     >>> X["sine"].head()
     2021-12-31 07:20:00   -1.0000

--- a/src/fold/transformations/scaling.py
+++ b/src/fold/transformations/scaling.py
@@ -23,7 +23,7 @@ class StandardScaler(WrapInvertibleSKLearnTransformation):
     >>> from fold.transformations import StandardScaler
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = StandardScaler()
     >>> X["sine"].head()
     2021-12-31 07:20:00    0.0000
@@ -79,7 +79,7 @@ class MinMaxScaler(WrapInvertibleSKLearnTransformation):
     >>> from fold.transformations import MinMaxScaler
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = MinMaxScaler()
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> X["sine"].loc[preds.index].head()

--- a/src/fold/transformations/window.py
+++ b/src/fold/transformations/window.py
@@ -63,7 +63,7 @@ class AddWindowFeatures(Transformation, Tunable):
     >>> from fold.transformations import AddWindowFeatures
     >>> from fold.utils.tests import generate_sine_wave_data
     >>> X, y  = generate_sine_wave_data()
-    >>> splitter = SlidingWindowSplitter(initial_train_window=0.5, step=0.2)
+    >>> splitter = SlidingWindowSplitter(train_window=0.5, step=0.2)
     >>> pipeline = AddWindowFeatures(("sine", 10, "mean"))
     >>> preds, trained_pipeline = train_backtest(pipeline, X, y, splitter)
     >>> preds.head()

--- a/tests/unit/test_splitters.py
+++ b/tests/unit/test_splitters.py
@@ -38,13 +38,13 @@ def test_expanding_window_splitter_embargo():
 
 def test_sliding_window_splitter():
     X, _ = generate_sine_wave_data(length=1000)
-    splitter = SlidingWindowSplitter(initial_train_window=400, step=400)
+    splitter = SlidingWindowSplitter(train_window=400, step=400)
 
     splits = splitter.splits(len(X))
     assert len(splits) == len(X) // 400
     assert splits[-1].test_window_end == len(X)
 
-    splitter = SlidingWindowSplitter(initial_train_window=0.4, step=0.4)
+    splitter = SlidingWindowSplitter(train_window=0.4, step=0.4)
 
     splits = splitter.splits(len(X))
     assert len(splits) == len(X) // 400
@@ -53,14 +53,14 @@ def test_sliding_window_splitter():
 
 def test_sliding_window_splitter_embargo():
     X, _ = generate_sine_wave_data(length=1000)
-    splitter = SlidingWindowSplitter(initial_train_window=400, step=400, embargo=10)
+    splitter = SlidingWindowSplitter(train_window=400, step=400, embargo=10)
 
     splits = splitter.splits(len(X))
     assert splits[-1].test_window_end == len(X)
     assert splits[0].train_window_end == 390
     assert splits[0].test_window_start == 400
 
-    splitter = SlidingWindowSplitter(initial_train_window=0.4, step=0.4, embargo=10)
+    splitter = SlidingWindowSplitter(train_window=0.4, step=0.4, embargo=10)
     splits = splitter.splits(len(X))
     assert splits[-1].test_window_end == len(X)
     assert splits[0].train_window_end == 390


### PR DESCRIPTION
Closes #309