### PR TITLE
feature(Utils): `ParsableEnum` now throws back the subclass type (Self) and checks for the `key` rather than the `value` in `from_str`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ numpy = ">=1.16"
 scikit-learn = ">=0.22"
 tqdm = ">=4.0"
 iteration_utilities = ">=0.11"
+typing_extensions = ">=4.4.0"
 
 black = {version = "~=22.12.0", optional = true}
 flake8 = {version = "~=4.0.1", optional = true}
@@ -58,6 +59,7 @@ fold-models = {version = "~=0.1.2", optional = true}
 fold-wrappers = {version = "~=0.1", optional = true}
 p_tqdm = {version = ">=1.3", optional = true}
 statsmodels = {version = ">=0.12.1", optional = true}
+
 
 [project.urls]
 Documentation = "https://dream-faster.github.io/fold"

--- a/src/fold/utils/enums.py
+++ b/src/fold/utils/enums.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from enum import Enum
 from typing import Union
 
+from typing_extensions import Self
+
 
 class ParsableEnum(Enum):
     @classmethod
-    def from_str(cls, value: Union[str, ParsableEnum]) -> ParsableEnum:
+    def from_str(cls, value: Union[str, ParsableEnum]) -> Self:
         if isinstance(value, cls):
             return value
         for item in cls:
-            if item.value == value:
+            if item.name == value:
                 return item
         else:
             raise ValueError(f"Unknown {cls.__name__}: {value}")


### PR DESCRIPTION
Closes #