### PR TITLE
feature(Tests): better tests for `Cache` Composite, don't copy trained_pipeline when backtesting with `ray`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,13 +121,4 @@ venv.bak/
 # MKdocs Gallery Generated
 docs/generated/*
 archive/*
-tests/unit/cache/artifacts.parquet
-tests/unit/cache/result.parquet
-tests/unit/cache/artifacts_fold0.parquet
-tests/unit/cache/artifacts_fold1.parquet
-tests/unit/cache/result_fold0.parquet
-tests/unit/cache/result_fold1.parquet
-tests/unit/cache/artifacts_linear_fold0.parquet
-tests/unit/cache/artifacts_linear_fold1.parquet
-tests/unit/cache/result_linear_fold0.parquet
-tests/unit/cache/result_linear_fold1.parquet
+tests/unit/cache/**

--- a/src/fold/loop/backend/ray.py
+++ b/src/fold/loop/backend/ray.py
@@ -55,6 +55,7 @@ def backtest_pipeline(
     func = ray.remote(func)
     X = ray.put(X)
     y = ray.put(y)
+    pipeline = ray.put(pipeline)
     return ray.get(
         [
             func.remote(pipeline, split, X, y, artifact, backend, mutate)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 import pytest
@@ -14,6 +15,7 @@ from fold.transformations.scaling import StandardScaler
 from fold.utils.tests import generate_monotonous_data
 
 folder = "tests/unit/cache/"
+os.makedirs("tests/unit/cache/", exist_ok=True)
 
 events_pipeline = [
     Cache(
@@ -42,6 +44,7 @@ normal_pipeline = [
 @pytest.mark.parametrize("pipeline", [events_pipeline, normal_pipeline])
 def test_cache(pipeline) -> None:
     X, y = generate_monotonous_data(1000, freq="1min")
+
     shutil.rmtree(folder)
 
     splitter = ExpandingWindowSplitter(initial_train_window=200, step=200)


### PR DESCRIPTION
Closes #